### PR TITLE
Remove unused einops import from LLaDA modeling

### DIFF
--- a/llada/model/modeling_llada.py
+++ b/llada/model/modeling_llada.py
@@ -62,7 +62,6 @@ from .configuration_llada import (
     ModelConfig,
     ActivationCheckpointingStrategy,
 )
-from einops import rearrange
 
 if sys.version_info.minor > 8:
     from collections.abc import MutableMapping


### PR DESCRIPTION
- einops library is not included in requirements.txt causing import errors 
- einops is only used in dead LLaDABlockDiffBlock class which is never instantiated
- No functional impact as the import was completely unused