### PR TITLE
Fix IndexError in get_transfer_index_dynamic in llada/generate.py for batch_size > 1

### DIFF
--- a/llada/generate.py
+++ b/llada/generate.py
@@ -385,6 +385,10 @@ def get_transfer_index_dynamic(logits, temperature, remasking, mask_index, x, nu
     num_transfer_tokens = mask_index.sum(dim=1, keepdim=True)
     
     for j in range(confidence.shape[0]):
+        num_tokens = int(num_transfer_tokens[j].item())
+        if num_tokens == 0:
+            continue
+        
         ns=list(range(1,num_transfer_tokens[j]+1))
         es=[factor/(n+1) for n in ns]
         threshs=[1-e for e in es]


### PR DESCRIPTION
## Description
Fix IndexError that occurs when using batch_size > 1 in `get_transfer_index_dynamic` function.

## Problem
When `batch_size > 1`, different samples may have different numbers of masked tokens. If a sample has no masked tokens (`num_transfer_tokens[j] == 0`), the `threshs` list becomes empty, causing an IndexError when accessing `threshs[0]`.

## Solution
Added a check to skip samples with no masked tokens before accessing the `threshs` list.

## Changes
- Added `if num_transfer_tokens[j] == 0: continue` check