### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Fast-DLLM
-[![Project](https://img.shields.io/static/v1?label=Project&message=Github&color=blue&logo=github-pages)](https://nvlabs.github.io/Fast-dLLM)
+[![Project](https://img.shields.io/static/v1?label=Project&message=Github&color=blue&logo=github-pages)](https://nvlabs.github.io/Fast-dLLM) [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVlabs/Fast-dLLM)
 [![arXiv](https://img.shields.io/badge/Paper-arXiv-red.svg)](https://arxiv.org/abs/2505.22618)
 <a href="https://fast-dllm.hanlab.ai"><img src="https://img.shields.io/static/v1?label=Demo&message=Fast-dLLM&color=yellow"></a> &ensp;
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NVlabs/Fast-dLLM) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.