### PR TITLE
fix: _init_dav_config is defined but never called

### DIFF
--- a/fast_ddrive/eval/batch_inference.py
+++ b/fast_ddrive/eval/batch_inference.py
@@ -194,6 +194,7 @@ class WaymoEvaluatorSpeculative:
         self.top_k = top_k
         self.section_block_steps = section_block_steps
         self.section_token_budgets = section_token_budgets
+        self._init_dav_config()
 
         print(f"[{device}] 加载 processor: {base_model}", flush=True)
         proc_kwargs = {}


### PR DESCRIPTION
### Problem
fix: _init_dav_config is defined but never called

### Fix
Replace:
```
        self.section_block_steps = section_block_steps
        self.section_token_budgets = section_token_budgets

        print(f"[{device}] 加载 processor: {base_model}", flush=True)
```

with:
```
        self.section_block_steps = section_block_steps
        self.section_token_budgets = section_token_budgets
        self._init_dav_config()

        print(f"[{device}] 加载 processor: {base_model}", flush=True)
```

### Files changed
- `fast_ddrive/eval/batch_inference.py`