### PR TITLE
fix: use total denoising steps for Humaneval dual cache evaluation

### DIFF
--- a/v1/llada/eval_humaneval.sh
+++ b/v1/llada/eval_humaneval.sh
@@ -34,7 +34,7 @@ accelerate launch eval_llada.py --tasks ${task} \
 # dual cache+parallel
 accelerate launch eval_llada.py --tasks ${task} \
 --confirm_run_unsafe_code --model llada_dist \
---model_args model_path='GSAI-ML/LLaDA-8B-Instruct',gen_length=${length},steps=${steps},block_length=${block_length},use_cache=True,dual_cache=True,threshold=0.9,show_speed=True \
+--model_args model_path='GSAI-ML/LLaDA-8B-Instruct',gen_length=${length},steps=${length},block_length=${block_length},use_cache=True,dual_cache=True,threshold=0.9,show_speed=True \
 --output_path evals_results/dual_cache_parallel/humaneval-ns0-${length} --log_samples
 
 ## NOTICE: use postprocess for humaneval


### PR DESCRIPTION
This is also inconsistent with the corresponding dual-cache configuration in `eval_gsm8k.sh`, which passes `steps=${length}`. For `length=256` and `block_length=32`, the current Humaneval command passes `steps=8`. Since `generate_with_dual_cache` computes `steps_per_block = steps // num_blocks`, this reduces to `1` step per block. This may also address the behavior reported in #66, where dual-cache evaluation on HumanEval produced 0 accuracy.